### PR TITLE
Re-enable the Realm-level permissions tests

### DIFF
--- a/Realm.xcodeproj/project.pbxproj
+++ b/Realm.xcodeproj/project.pbxproj
@@ -217,6 +217,8 @@
 		3FAB084C1E1EC3A2001BC8DA /* sync_metadata.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 1A1536701DB0464800C0EC93 /* sync_metadata.hpp */; };
 		3FAB08881E1EC51F001BC8DA /* object_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3FAB08861E1EC51F001BC8DA /* object_notifier.cpp */; };
 		3FAB08891E1EC526001BC8DA /* object_notifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3FAB08861E1EC51F001BC8DA /* object_notifier.cpp */; };
+		3FAD40B7219E3F8700509E5B /* RLMPermissionsAPITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AD6E7A51E8C2BDF00D4C8B4 /* RLMPermissionsAPITests.m */; };
+		3FAD40B9219E3F9200509E5B /* SwiftPermissionsAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A877BEE1EAE9F79001BEC40 /* SwiftPermissionsAPITests.swift */; };
 		3FB4FA1719F5D2740020D53B /* SwiftTestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F8D90B196CB8DD00475368 /* SwiftTestObjects.swift */; };
 		3FB4FA1819F5D2740020D53B /* SwiftArrayPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E82FA60A195632F20043A3C3 /* SwiftArrayPropertyTests.swift */; };
 		3FB4FA1919F5D2740020D53B /* SwiftArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E82FA60B195632F20043A3C3 /* SwiftArrayTests.swift */; };
@@ -1482,9 +1484,9 @@
 				5DD755CF1BE056DE002800DA /* Realm.framework */,
 				5D660FD81BE98C7C0021E04F /* RealmSwift Tests.xctest */,
 				5D660FCC1BE98C560021E04F /* RealmSwift.framework */,
+				3F9D91872152D42F00474F09 /* TestHost static.app */,
 				3F1A5E721992EB7400F45F4C /* TestHost.app */,
 				E8D89BA31955FC6D00CF2B9A /* Tests.xctest */,
-				3F9D91872152D42F00474F09 /* TestHost static.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2446,6 +2448,7 @@
 				1A2713D71E3BBAC8001F6BFC /* RLMAncillaryObjectServerTests.m in Sources */,
 				1A2D7A521DA5BCEC006AD7D6 /* RLMMultiProcessTestCase.m in Sources */,
 				E8267FF11D90B8E700E001C7 /* RLMObjectServerTests.mm in Sources */,
+				3FAD40B7219E3F8700509E5B /* RLMPermissionsAPITests.m in Sources */,
 				3FB60BAB204095B500583735 /* RLMPermissionsTests.mm in Sources */,
 				1AF64DCF1DA3042B0081EB15 /* RLMSyncManager+ObjectServerTests.m in Sources */,
 				3F73BC911E3A877300FE80B6 /* RLMSyncSessionRefreshHandle+ObjectServerTests.m in Sources */,
@@ -2454,6 +2457,7 @@
 				E86E61241D91E4E200DC2419 /* RLMTestCase.m in Sources */,
 				3F73BC921E3A877300FE80B6 /* RLMTestUtils.m in Sources */,
 				1AA5AEA11D98C99800ED8C27 /* SwiftObjectServerTests.swift in Sources */,
+				3FAD40B9219E3F9200509E5B /* SwiftPermissionsAPITests.swift in Sources */,
 				3FB60BAD2040999300583735 /* SwiftPermissionsTests.swift in Sources */,
 				1AA5AE981D989BE400ED8C27 /* SwiftSyncTestCase.swift in Sources */,
 			);

--- a/Realm/ObjectServerTests/RLMPermissionsAPITests.m
+++ b/Realm/ObjectServerTests/RLMPermissionsAPITests.m
@@ -18,8 +18,6 @@
 
 #import <XCTest/XCTest.h>
 
-// FIXME: Many permission tests appears to fail with the ROS 3.0.0 alpha releases.
-
 #import "RLMSyncTestCase.h"
 
 #import "RLMTestUtils.h"
@@ -33,8 +31,31 @@
         XCTAssertNil(err, @"Received an error when applying permission: %@", err);                                     \
         [ex fulfill];                                                                                                  \
     }];                                                                                                                \
-    [self waitForExpectationsWithTimeout:10.0 handler:nil];                                                            \
+    [self waitForExpectations:@[ex] timeout:2.0];                                                                      \
 }                                                                                                                      \
+
+#define CHECK_COUNT_PENDING_DOWNLOAD(expected_count, m_type, m_realm) \
+    CHECK_COUNT_PENDING_DOWNLOAD_CUSTOM_EXPECTATION(expected_count, m_type, m_realm, nil)
+
+/// This macro tries ten times to wait for downloads and then check for object count.
+/// If the object count does not match, it waits 0.1 second before trying again.
+/// It is most useful in cases where the test ROS might be expected to take some
+/// non-negligible amount of time performing an operation whose completion is required
+/// for the test on the client side to proceed.
+#define CHECK_COUNT_PENDING_DOWNLOAD_CUSTOM_EXPECTATION(expected_count, m_type, m_realm, m_exp)                        \
+{                                                                                                                      \
+    RLMSyncConfiguration *m_config = m_realm.configuration.syncConfiguration;                                          \
+    XCTAssertNotNil(m_config, @"Realm passed to CHECK_COUNT_PENDING_DOWNLOAD() doesn't have a sync config!");          \
+    RLMSyncUser *m_user = m_config.user;                                                                               \
+    NSURL *m_url = m_config.realmURL;                                                                                  \
+    for (int i=0; i<10; i++) {                                                                                         \
+        [self waitForDownloadsForUser:m_user url:m_url expectation:m_exp error:nil];                                   \
+        if (expected_count == [m_type allObjectsInRealm:m_realm].count) { break; }                                     \
+        [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];                           \
+    }                                                                                                                  \
+    CHECK_COUNT(expected_count, m_type, m_realm);                                                                      \
+}
+
 
 static NSURL *makeTestURL(NSString *name, RLMSyncUser *owner) {
     NSString *userID = [owner identity] ?: @"~";
@@ -228,7 +249,7 @@ static NSURL *makeTildeSubstitutedURL(NSURL *url, RLMSyncUser *user) {
 
     // Have user A add some items to the Realm.
     [self addSyncObjectsToRealm:userARealm descriptions:@[@"child-1", @"child-2", @"child-3"]];
-    [self waitForUploadsForUser:self.userA url:userAURL];
+    [self waitForUploadsForRealm:userARealm];
     CHECK_COUNT(3, SyncObject, userARealm);
 
     // Give user B read permissions to that Realm.
@@ -303,7 +324,7 @@ static NSURL *makeTildeSubstitutedURL(NSURL *url, RLMSyncUser *user) {
 
     // Have user A add some items to the Realm.
     [self addSyncObjectsToRealm:userARealm descriptions:@[@"child-1", @"child-2", @"child-3"]];
-    [self waitForUploadsForUser:self.userA url:userAURL];
+    [self waitForUploadsForRealm:userARealm];
     CHECK_COUNT(3, SyncObject, userARealm);
 
     // Give user B write permissions to that Realm.
@@ -320,7 +341,7 @@ static NSURL *makeTildeSubstitutedURL(NSURL *url, RLMSyncUser *user) {
 
     // Add some objects using user B.
     [self addSyncObjectsToRealm:userBRealm descriptions:@[@"child-4", @"child-5"]];
-    [self waitForUploadsForUser:self.userB url:userBURL];
+    [self waitForUploadsForRealm:userBRealm];
     CHECK_COUNT(5, SyncObject, userBRealm);
     CHECK_COUNT_PENDING_DOWNLOAD(5, SyncObject, userARealm);
 
@@ -359,7 +380,7 @@ static NSURL *makeTildeSubstitutedURL(NSURL *url, RLMSyncUser *user) {
 
     // Have user A add some items to the Realm.
     [self addSyncObjectsToRealm:userARealm descriptions:@[@"child-1", @"child-2", @"child-3"]];
-    [self waitForUploadsForUser:self.userA url:userAURLUnresolved];
+    [self waitForUploadsForRealm:userARealm];
     CHECK_COUNT(3, SyncObject, userARealm);
 
     // Give user B admin permissions to that Realm.
@@ -375,7 +396,7 @@ static NSURL *makeTildeSubstitutedURL(NSURL *url, RLMSyncUser *user) {
 
     // Add some objects using user B.
     [self addSyncObjectsToRealm:userBRealm descriptions:@[@"child-4", @"child-5"]];
-    [self waitForUploadsForUser:self.userB url:userAURLResolved];
+    [self waitForUploadsForRealm:userBRealm];
     CHECK_COUNT(5, SyncObject, userBRealm);
     CHECK_COUNT_PENDING_DOWNLOAD(5, SyncObject, userARealm);
 
@@ -389,7 +410,7 @@ static NSURL *makeTildeSubstitutedURL(NSURL *url, RLMSyncUser *user) {
     RLMRealm *userCRealm = [self openRealmForURL:userAURLResolved user:self.userC];
     CHECK_COUNT_PENDING_DOWNLOAD(5, SyncObject, userCRealm);
     [self addSyncObjectsToRealm:userCRealm descriptions:@[@"child-6", @"child-7", @"child-8"]];
-    [self waitForUploadsForUser:self.userC url:userAURLResolved];
+    [self waitForUploadsForRealm:userCRealm];
     CHECK_COUNT(8, SyncObject, userCRealm);
     CHECK_COUNT_PENDING_DOWNLOAD(8, SyncObject, userARealm);
     CHECK_COUNT_PENDING_DOWNLOAD(8, SyncObject, userBRealm);
@@ -413,7 +434,7 @@ static NSURL *makeTildeSubstitutedURL(NSURL *url, RLMSyncUser *user) {
 
     // Have user A add some items to the Realm.
     [self addSyncObjectsToRealm:userARealm descriptions:@[@"child-1", @"child-2", @"child-3"]];
-    [self waitForUploadsForUser:self.userA url:userAURL];
+    [self waitForUploadsForRealm:userARealm];
     CHECK_COUNT(3, SyncObject, userARealm);
 
     // Give user B write permissions to that Realm via user B's username.
@@ -431,7 +452,7 @@ static NSURL *makeTildeSubstitutedURL(NSURL *url, RLMSyncUser *user) {
 
     // Add some objects using user B.
     [self addSyncObjectsToRealm:userBRealm descriptions:@[@"child-4", @"child-5"]];
-    [self waitForUploadsForUser:self.userB url:userBURL];
+    [self waitForUploadsForRealm:userBRealm];
     CHECK_COUNT(5, SyncObject, userBRealm);
     CHECK_COUNT_PENDING_DOWNLOAD(5, SyncObject, userARealm);
 }
@@ -454,21 +475,21 @@ static NSURL *makeTildeSubstitutedURL(NSURL *url, RLMSyncUser *user) {
 
     // Have user A write a few objects first.
     [self addSyncObjectsToRealm:userARealm descriptions:@[@"child-1", @"child-2", @"child-3"]];
-    [self waitForUploadsForUser:self.userA url:ownerURL];
+    [self waitForUploadsForRealm:userARealm];
     CHECK_COUNT(3, SyncObject, userARealm);
 
     // User B should be able to write to the Realm.
     RLMRealm *userBRealm = [self openRealmForURL:guestURL user:self.userB];
     CHECK_COUNT_PENDING_DOWNLOAD(3, SyncObject, userBRealm);
     [self addSyncObjectsToRealm:userBRealm descriptions:@[@"child-4", @"child-5"]];
-    [self waitForUploadsForUser:self.userB url:guestURL];
+    [self waitForUploadsForRealm:userBRealm];
     CHECK_COUNT(5, SyncObject, userBRealm);
 
     // User C should be able to write to the Realm.
     RLMRealm *userCRealm = [self openRealmForURL:guestURL user:self.userC];
     CHECK_COUNT_PENDING_DOWNLOAD(5, SyncObject, userCRealm);
     [self addSyncObjectsToRealm:userCRealm descriptions:@[@"child-6", @"child-7", @"child-8", @"child-9"]];
-    [self waitForUploadsForUser:self.userC url:guestURL];
+    [self waitForUploadsForRealm:userCRealm];
     CHECK_COUNT(9, SyncObject, userCRealm);
 }
 
@@ -492,7 +513,7 @@ static NSURL *makeTildeSubstitutedURL(NSURL *url, RLMSyncUser *user) {
 
     // Have the admin user write a few objects first.
     [self addSyncObjectsToRealm:adminUserRealm descriptions:@[@"child-1", @"child-2", @"child-3"]];
-    [self waitForUploadsForUser:admin url:globalRealmURL];
+    [self waitForUploadsForRealm:adminUserRealm];
     CHECK_COUNT(3, SyncObject, adminUserRealm);
 
     // User B should be able to read from the Realm.
@@ -548,21 +569,21 @@ static NSURL *makeTildeSubstitutedURL(NSURL *url, RLMSyncUser *user) {
 
     // Have the admin user write a few objects first.
     [self addSyncObjectsToRealm:adminUserRealm descriptions:@[@"child-1", @"child-2", @"child-3"]];
-    [self waitForUploadsForUser:admin url:globalRealmURL];
+    [self waitForUploadsForRealm:adminUserRealm];
     CHECK_COUNT(3, SyncObject, adminUserRealm);
 
     // User B should be able to write to the Realm.
     RLMRealm *userBRealm = [self openRealmForURL:globalRealmURL user:self.userB];
     CHECK_COUNT_PENDING_DOWNLOAD(3, SyncObject, userBRealm);
     [self addSyncObjectsToRealm:userBRealm descriptions:@[@"child-4", @"child-5"]];
-    [self waitForUploadsForUser:self.userB url:globalRealmURL];
+    [self waitForUploadsForRealm:userBRealm];
     CHECK_COUNT(5, SyncObject, userBRealm);
 
     // User C should be able to write to the Realm.
     RLMRealm *userCRealm = [self openRealmForURL:globalRealmURL user:self.userC];
     CHECK_COUNT_PENDING_DOWNLOAD(5, SyncObject, userCRealm);
     [self addSyncObjectsToRealm:userCRealm descriptions:@[@"child-6", @"child-7", @"child-8", @"child-9"]];
-    [self waitForUploadsForUser:self.userC url:globalRealmURL];
+    [self waitForUploadsForRealm:userCRealm];
     CHECK_COUNT(9, SyncObject, userCRealm);
 }
 
@@ -1136,7 +1157,7 @@ static NSURL *makeTildeSubstitutedURL(NSURL *url, RLMSyncUser *user) {
 
     // Have user A add some items to the Realm.
     [self addSyncObjectsToRealm:userARealm descriptions:@[@"child-1", @"child-2", @"child-3"]];
-    [self waitForUploadsForUser:self.userA url:userAURL];
+    [self waitForUploadsForRealm:userARealm];
     CHECK_COUNT(3, SyncObject, userARealm);
 
     // Give user B read permissions to that Realm.

--- a/Realm/ObjectServerTests/SwiftPermissionsAPITests.swift
+++ b/Realm/ObjectServerTests/SwiftPermissionsAPITests.swift
@@ -19,7 +19,7 @@
 import XCTest
 import RealmSwift
 
-class SwiftPermissionsAPITests: SwiftSyncTestCase {
+class SwiftRealmPermissionsAPITests: SwiftSyncTestCase {
     var userA: SyncUser!
     var userB: SyncUser!
     var userC: SyncUser!
@@ -175,7 +175,7 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
             results = r
             ex.fulfill()
         }
-        waitForExpectations(timeout: 2.0, handler: nil)
+        wait(for: [ex], timeout: 2.0)
 
         // Open a Realm for user A.
         let uuid = UUID().uuidString
@@ -205,7 +205,7 @@ class SwiftPermissionsAPITests: SwiftSyncTestCase {
             XCTAssertNil(error)
             ex2.fulfill()
         }
-        waitForExpectations(timeout: 2.0, handler: nil)
+        wait(for: [ex2], timeout: 2.0)
 
         // Wait for the notification to be fired.
         wait(for: [noteEx], timeout: 2.0)


### PR DESCRIPTION
These were disabled because the permissions server was broken in alpha versions
of ROS 3.0 and we were considering just removing the functionality entirely,
but it's now back to working and will stick around.